### PR TITLE
Plone 4.3 compatibility (import)

### DIFF
--- a/eea/forms/widgets/ManagementPlanWidget.py
+++ b/eea/forms/widgets/ManagementPlanWidget.py
@@ -5,7 +5,10 @@ from Products.Archetypes.Widget import TypesWidget
 from zope.app.form.browser.interfaces import IBrowserWidget
 from zope.app.form.interfaces import IInputWidget
 from zope.app.form.interfaces import WidgetInputError
-from zope.app.pagetemplate import ViewPageTemplateFile
+try:
+    from zope.app.pagetemplate import ViewPageTemplateFile
+except ImportError: # plone 4.3
+    from zope.browserpage import ViewPageTemplateFile
 from zope.interface import implements
 from zope.schema import Field
 from zope.schema.vocabulary import getVocabularyRegistry


### PR DESCRIPTION
The imports were not Plone 4.3 compatible, e.g.:

> from zope.app.pagetemplate import ViewPageTemplateFile
> zope.configuration.xmlconfig.ZopeXMLConfigurationError: File >"/home/lepri/trabalho/observatorio/observatorio.buildout/parts/instance/etc/site.zcml", line 12.2->12.39
>    ZopeXMLConfigurationError: File "/home/lepri/.cache/eggs/Products.CMFPlone-4.3->py2.7.egg/Products/CMFPlone/meta.zcml", line 42.4-46.10
>   ImportError: No module named pagetemplate

I used zope.browserpage.viewpagetemplatefile.ViewPageTemplateFile instead of zope.app.pagetemplate.viewpagetemplatefile.ViewPageTemplateFile.
